### PR TITLE
docs(CONDUCT.md) fix link URL

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -20,6 +20,5 @@ from the project team.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by 
 opening an issue or contacting one or more of the project maintainers.
 
-This Code of Conduct is adapted from the Contributor Covenant 
-(http:contributor-covenant.org), version 1.0.0, available at 
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.0.0, available at 
 http://contributor-covenant.org/version/1/0/0/


### PR DESCRIPTION
- Fix link URL by adding missing `//` characters to it.
- Add Markdown syntax to make link more readable.